### PR TITLE
Permissions table improvements

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,9 @@ Changelog
 - replace checkboxes with mark symbols in permission matrix
   [gaudenz]
 
+- permission matrix display improvements
+  [gaudenz]
+
 1.0a2 (13/11/2011)
 ------------------
 

--- a/src/plone/app/debugtoolbar/browser/resources/debugtoolbar.css
+++ b/src/plone/app/debugtoolbar/browser/resources/debugtoolbar.css
@@ -276,12 +276,17 @@
   padding: 0;
   font-size: 13px;
   border-collapse: collapse;
+  border-spacing: 0;
 }
 #debug-toolbar table th,
 #debug-toolbar table td {
   padding: 10px 10px 9px;
   line-height: 18px;
   text-align: left;
+}
+#debug-toolbar table td.mark {
+  text-align: center;
+  vertical-align: middle;
 }
 #debug-toolbar table th {
   padding-top: 9px;

--- a/src/plone/app/debugtoolbar/browser/workflow.pt
+++ b/src/plone/app/debugtoolbar/browser/workflow.pt
@@ -34,7 +34,7 @@
 
     <h3 i18n:translate="">Permission matrix</h3>
 
-    <table class="zebra-striped">
+    <table class="zebra-striped condensed-table bordered-table">
         <thead>
             <tr>
                 <th i18n:translate="">Name</th>


### PR DESCRIPTION
Two small improvements to the permission matrix. Without the first one the html selection tool in Firbug is mostly unusable as Firefox stalls for several seconds when it's activated or deactivated. Not using checkboxes works around this bug.
