### PR TITLE
Plone 5 + tiles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,13 @@ Changelog
 
 New:
 
+- Add a ``plone.app.debugtoolbar.toolbar`` tile for displaying in plone.app.blocks layouts.
+  [thet]
+
+- Plone 5 compatibility: Don't register JS and CSS but include them inline.
+  Includes upgrade step.
+  [thet]
+
 - Added panel with catalog info: indexed values and metadata of the current
   object.
   [sunew]

--- a/src/plone/app/debugtoolbar/browser/configure.zcml
+++ b/src/plone/app/debugtoolbar/browser/configure.zcml
@@ -1,6 +1,8 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="plone">
 
     <include package="Products.CMFCore" file="permissions.zcml" />
@@ -26,6 +28,15 @@
         class="plone.app.viewletmanager.manager.OrderedViewletManager"
         layer=".interfaces.IDebugToolbarLayer"
         />
+
+    <configure zcml:condition="installed plone.app.standardtiles">
+      <plone:tile
+          name="plone.app.debugtoolbar.toolbar"
+          class=".tile.ToolbarTile"
+          for="*"
+          permission="zope2.View"
+          />
+    </configure>
 
     <!-- Panels -->
 

--- a/src/plone/app/debugtoolbar/browser/tile.py
+++ b/src/plone/app/debugtoolbar/browser/tile.py
@@ -1,0 +1,7 @@
+from plone.app.standardtiles.common import ProxyViewletTile
+
+
+class ToolbarTile(ProxyViewletTile):
+    """A footer tile."""
+    manager = 'plone.portalfooter'
+    viewlet = 'plone.app.debugtoolbar.toolbar'

--- a/src/plone/app/debugtoolbar/browser/toolbar.pt
+++ b/src/plone/app/debugtoolbar/browser/toolbar.pt
@@ -7,8 +7,11 @@
 
 <a id="debug-toolbar-trigger" class="debug-toolbar-trigger-button" href="#debug-toolbar" i18n:translate="debug_toolbar_trigger">&darr; Debug</a>
 <div id="debug-toolbar">
-    
+
     <div id="debug-toolbar-wrapper">
+
+        <link rel="stylesheet" href="++resource++plone.app.debugtoolbar/debugtoolbar.css" type="text/css" media="screen" charset="utf-8"/>
+        <script type="text/javascript" charset="utf-8" src="++resource++plone.app.debugtoolbar/debugtoolbar.js"/>
 
         <h1 i18n:translate="debug_toolbar_title">Debug information</h1>
         <a href="#" id="debug-toolbar-close" class="debug-toolbar-trigger-button" i18n:translate="debug_toolbar_close">&uarr; Close</a>
@@ -18,4 +21,5 @@
     </div>
 
 </div>
+
 </html>

--- a/src/plone/app/debugtoolbar/configure.zcml
+++ b/src/plone/app/debugtoolbar/configure.zcml
@@ -5,11 +5,16 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     i18n_domain="plone">
   
+  <i18n:registerTranslations directory="locales" />
+  
   <include package="zope.annotation" />
   <include package="plone.transformchain" />
   <include package=".browser" />
 
-  <i18n:registerTranslations directory="locales" />
+  <adapter
+      factory=".delayedwrite.DelayedWriteTransformer"
+      name="plone.app.debugtoolbar.delayedwrite"
+      />
 
   <genericsetup:registerProfile
       name="default"
@@ -20,7 +25,6 @@
       i18n:attributes="title gs_profiles_default_title;
                        description gs_profiles_default_description;"
       />
-
   <genericsetup:registerProfile
       name="uninstall"
       title="Plone debug toolbar Uninstall Profile"
@@ -30,12 +34,13 @@
       i18n:attributes="title gs_profiles_uninstall_title;
                        description gs_profiles_uninstall_description;"
       />
-
-  <!-- -*- extra stuff goes here -*- -->
-  
-  <adapter
-      factory=".delayedwrite.DelayedWriteTransformer"
-      name="plone.app.debugtoolbar.delayedwrite"
+  <genericsetup:upgradeStep
+      title="Remove CSS and JS from registry."
+      source="1"
+      destination="2"
+      sortkey="1"
+      handler=".upgrades.upgrade_1_to_2"
+      profile="plone.app.debugtoolbar:default"
       />
-
+  
 </configure>

--- a/src/plone/app/debugtoolbar/profiles/default/cssregistry.xml
+++ b/src/plone/app/debugtoolbar/profiles/default/cssregistry.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0"?>
-<object name="portal_css">
-
-    <stylesheet id="++resource++plone.app.debugtoolbar/debugtoolbar.css" />
-
-</object>

--- a/src/plone/app/debugtoolbar/profiles/default/jsregistry.xml
+++ b/src/plone/app/debugtoolbar/profiles/default/jsregistry.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0"?>
-<object name="portal_javascripts">
-
-    <javascript id="++resource++plone.app.debugtoolbar/debugtoolbar.js" />
-
-</object>

--- a/src/plone/app/debugtoolbar/profiles/default/metadata.xml
+++ b/src/plone/app/debugtoolbar/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1</version>
+  <version>2</version>
 </metadata>

--- a/src/plone/app/debugtoolbar/profiles/uninstall/cssregistry.xml
+++ b/src/plone/app/debugtoolbar/profiles/uninstall/cssregistry.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0"?>
-<object name="portal_css">
-
-    <stylesheet id="++resource++plone.app.debugtoolbar/debugtoolbar.css" remove="True" />
-
-</object>

--- a/src/plone/app/debugtoolbar/profiles/uninstall/jsregistry.xml
+++ b/src/plone/app/debugtoolbar/profiles/uninstall/jsregistry.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0"?>
-<object name="portal_javascripts">
-
-    <javascript id="++resource++plone.app.debugtoolbar/debugtoolbar.js" remove="True" />
-
-</object>

--- a/src/plone/app/debugtoolbar/upgrades.py
+++ b/src/plone/app/debugtoolbar/upgrades.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from Products.CMFCore.utils import getToolByName
+
+import logging
+
+
+logger = logging.getLogger('plone.app.debugtoolbar upgrade')
+
+
+def upgrade_1_to_2(context):
+    """Remove JS and CSS resources from portal_css and portal_js registry.
+    """
+    def unregister_resource(registry, resource):
+        if registry and registry.getResource(resource):
+            registry.unregisterResource(resource)
+            logger.info("Removed {0} from {1}".format(resource, registry.id))
+
+    # Unregister JavaScript
+    unregister_resource(
+        getToolByName(context, 'portal_javascripts'),
+        '++resource++plone.app.debugtoolbar/debugtoolbar.js'
+    )
+
+    # Unregister CSS
+    unregister_resource(
+        getToolByName(context, 'portal_css'),
+        '++resource++plone.app.debugtoolbar/debugtoolbar.css'
+    )


### PR DESCRIPTION
- Add a ``plone.app.debugtoolbar.toolbar`` tile for displaying in plone.app.blocks layouts.
- Plone 5 compatibility: Don't register JS and CSS but include them inline.
  Includes upgrade step.