### PR TITLE
Fix FileNotFoundError on str(attr) when attr is <App.special_dtml.DTM…

### DIFF
--- a/news/34.bugfix
+++ b/news/34.bugfix
@@ -1,0 +1,2 @@
+Fix FileNotFoundError on str(attr) when attr is <App.special_dtml.DTMLFile object at 0x109b2c530>
+[pbauer]

--- a/src/plone/app/debugtoolbar/browser/context.py
+++ b/src/plone/app/debugtoolbar/browser/context.py
@@ -170,10 +170,15 @@ class ContextViewlet(ViewletBase):
                         }
                     )
             else:
+                try:
+                    value_repr = str(attr)
+                except Exception:
+                    value_repr = attr.__repr__()
+
                 self.variables.append(
                     {
                         "name": name,
                         "primitive": False,
-                        "value": str(attr),
+                        "value": value_repr,
                     }
                 )


### PR DESCRIPTION
…LFile object at 0x109b2c530>

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

